### PR TITLE
fix: macOS installation and Docker setup improvements

### DIFF
--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -22,6 +22,7 @@ services:
       nofile:
         soft: 4096
         hard: 8192
+      nproc: 4096
 
   openclaw-cli:
     read_only: true


### PR DESCRIPTION
## Context & Purpose

- Improves macOS installation experience and fixes Docker-related issues that cause crash-loops on certain setups
- Makes reset and troubleshooting workflows clearer for users

## What changed

- **Docker compose**: Disabled `init` for openclaw-gateway and openclaw-cli services to prevent crash-loops on certain Linux Docker setups
- **Port binding**: Added `docker-compose.ports.localhost.yml` for local port exposure; removed local port exposure from `docker-compose.secure.yml` and `docker-compose.yml`
- **Reset script**: Introduced `scripts/reset.sh` for project reset with options for deleting config, source, and workspace
- **Docs**: Expanded `INSTALL-macos.md` and `RESET-macos.md` with troubleshooting steps and reset instructions
- **Scripts**: Improved error handling and troubleshooting guidance in `dashboard.sh` and `_common.sh`
- **Other**: Added `.env.example` to `.gitignore`

## How to test

```bash
./scripts/setup.sh
./scripts/up.sh
./scripts/cli.sh status
./scripts/dashboard.sh
./scripts/reset.sh --help
```

## Checklist

- [x] No secrets/tokens/private paths were committed (especially `.env`)
- [x] Docs updated if user workflow changed
- [x] Changes are scoped and easy to review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compose-only configuration change to process init behavior; main risk is slightly different signal/zombie reaping semantics for these containers.
> 
> **Overview**
> Disables Docker `init` for `openclaw-gateway` and `openclaw-cli` in `docker-compose.secure.yml`, with a note explaining this avoids crash-loops on some Linux setups when combined with hardening (`read_only`, dropped caps, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2a6c6a408e6485d78210a5fb161b7039be455d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->