### PR TITLE
feat: default OpenClaw source clone to upstream openclaw/openclaw

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -6,8 +6,8 @@ alwaysApply: true
 # Wrapper Repo Rules
 
 - Treat this repository as the deployment wrapper around OpenClaw, not the main OpenClaw source tree.
-- The OpenClaw source is cloned from `OPENCLAW_GIT_REPO` into `OPENCLAW_SRC_DIR`; in local dev it may exist as the sibling repo `../messyvirgo-openclaw`.
-- Keep the source fork clean and upstream-syncable; keep wrapper concerns in this repo and put Messy Virgo agent/skill customizations in `../messyvirgo-openclaw-agents` unless a source-level change is truly required.
+- The OpenClaw source is cloned from `OPENCLAW_GIT_REPO` (default upstream) into `OPENCLAW_SRC_DIR`; in local dev the checkout often lives as a sibling directory (e.g. `../messyvirgo-openclaw` or `../openclaw`).
+- Track upstream OpenClaw for source changes; keep wrapper concerns in this repo and put Messy Virgo agent/skill customizations in `../messyvirgo-openclaw-agents` unless a source-level change is truly required.
 - Keep changes small and reviewable; avoid broad refactors without clear need.
 - Do not hardcode secrets, tokens, private URLs, or machine-specific paths.
 - If behavior changes, update docs or comments in the same PR when needed.

--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ BRAVE_API_KEY=
 MESSY_VIRGO_MCP_URL=https://api.messyvirgo.com/mcp
 MESSY_VIRGO_API_KEY=
 
-# Git repo to clone for building (set to upstream to track openclaw/openclaw)
-OPENCLAW_GIT_REPO=https://github.com/messyvirgo-coin/messyvirgo-openclaw
+# OpenClaw source repo for clone/pull (default: upstream). Override for a fork or mirror.
+OPENCLAW_GIT_REPO=https://github.com/openclaw/openclaw
 
 # Where OpenClaw stores secrets/config/sessions on your host
 OPENCLAW_CONFIG_DIR=$HOME/.openclaw-secure

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This code is provided **as-is** and maintained **best-effort**. PRs/issues are w
 Why not use "Update now" in the UI?
 
 - This wrapper runs OpenClaw from a Docker image, so in-app self-update is typically skipped with `reason: "not-git-install"` (runtime path is usually `/app`).
-- In container/immutable deployments, the correct update path is: sync fork -> rebuild image -> restart container via `./scripts/upgrade.sh`.
+- In container/immutable deployments, the correct update path is: pull the latest OpenClaw source (via `./scripts/upgrade.sh`, which updates your clone from `OPENCLAW_GIT_REPO`) -> rebuild image -> restart container.
 
 If you want to apply updated wrapper config templates (including security
 defaults) to an existing deployment, run:

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -57,7 +57,7 @@ If your MCP server runs locally on the same Linux host:
 
 Other values you can optionally edit in `.env` before running setup:
 
-- **`OPENCLAW_GIT_REPO`**: source repo to clone/pull (default: Messy Virgo fork; optional: upstream OpenClaw repo)
+- **`OPENCLAW_GIT_REPO`**: source repo to clone/pull (default: upstream [`openclaw/openclaw`](https://github.com/openclaw/openclaw); override for a fork or mirror)
 - **`OPENCLAW_SRC_DIR`**: local source checkout used to build the Docker image
 - **`OPENCLAW_IMAGE`**: image name to build locally
 - **`OPENCLAW_CONFIG_DIR`** and **`OPENCLAW_WORKSPACES_DIR`**: host state/workspace paths

--- a/docs/INSTALL-macos.md
+++ b/docs/INSTALL-macos.md
@@ -52,7 +52,7 @@ If you plan to install the Messy Virgo Agents and Skills Pack, add these values 
 
 Other values you can optionally edit in `.env` before running setup:
 
-- **`OPENCLAW_GIT_REPO`**: source repo to clone/pull (default: Messy Virgo fork; optional: upstream OpenClaw repo)
+- **`OPENCLAW_GIT_REPO`**: source repo to clone/pull (default: upstream [`openclaw/openclaw`](https://github.com/openclaw/openclaw); override for a fork or mirror)
 - **`OPENCLAW_SRC_DIR`**: local source checkout used to build the Docker image
 - **`OPENCLAW_IMAGE`**: image name to build locally
 - **`OPENCLAW_CONFIG_DIR`** and **`OPENCLAW_WORKSPACES_DIR`**: host state/workspace paths

--- a/envs/cloud.env.example
+++ b/envs/cloud.env.example
@@ -8,8 +8,8 @@ BANKR_API_KEY=
 OPENROUTER_API_KEY=
 BRAVE_API_KEY=
 
-# Git repo to clone for building (set to upstream to track openclaw/openclaw)
-OPENCLAW_GIT_REPO=https://github.com/messyvirgo-coin/messyvirgo-openclaw
+# OpenClaw source repo for clone/pull (default: upstream). Override for a fork or mirror.
+OPENCLAW_GIT_REPO=https://github.com/openclaw/openclaw
 
 # Where OpenClaw stores secrets/config/sessions on your host
 OPENCLAW_CONFIG_DIR=$HOME/.openclaw-secure

--- a/envs/local.env.example
+++ b/envs/local.env.example
@@ -8,8 +8,8 @@ BANKR_API_KEY=
 OPENROUTER_API_KEY=
 BRAVE_API_KEY=
 
-# Git repo to clone for building (set to upstream to track openclaw/openclaw)
-OPENCLAW_GIT_REPO=https://github.com/messyvirgo-coin/messyvirgo-openclaw
+# OpenClaw source repo for clone/pull (default: upstream). Override for a fork or mirror.
+OPENCLAW_GIT_REPO=https://github.com/openclaw/openclaw
 
 # Where OpenClaw stores secrets/config/sessions on your host
 OPENCLAW_CONFIG_DIR=$HOME/.openclaw-secure

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -113,7 +113,7 @@ else
   DEFAULT_WORKSPACES_DIR="$HOME/OpenClawWorkspaces"
 fi
 DEFAULT_SRC_DIR="${OPENCLAW_SRC_DIR:-$DEFAULT_CONFIG_DIR/openclaw-src}"
-DEFAULT_GIT_REPO="${OPENCLAW_GIT_REPO:-https://github.com/messyvirgo-coin/messyvirgo-openclaw}"
+DEFAULT_GIT_REPO="${OPENCLAW_GIT_REPO:-https://github.com/openclaw/openclaw}"
 DEFAULT_IMAGE="${OPENCLAW_IMAGE:-openclaw-secure:local}"
 DEFAULT_NPM_VERSION="${OPENCLAW_NPM_VERSION:-11.11.1}"
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -51,7 +51,7 @@ if [[ -z "${OPENCLAW_SRC_DIR:-}" ]]; then
   die "OPENCLAW_SRC_DIR is not set. Run scripts/setup.sh first."
 fi
 if [[ -z "${OPENCLAW_GIT_REPO:-}" ]]; then
-  OPENCLAW_GIT_REPO="https://github.com/messyvirgo-coin/messyvirgo-openclaw"
+  OPENCLAW_GIT_REPO="https://github.com/openclaw/openclaw"
 fi
 if [[ -z "${OPENCLAW_NPM_VERSION:-}" ]]; then
   OPENCLAW_NPM_VERSION="11.11.1"


### PR DESCRIPTION
## Context & Purpose

- Point new setups and upgrades at upstream [openclaw/openclaw](https://github.com/openclaw/openclaw) by default instead of the Messy Virgo fork (fork is being discontinued).
- Aligns wrapper docs, env examples, Cursor rules, and script fallbacks so `OPENCLAW_GIT_REPO` is optional and upstream unless overridden.

## What changed

- **`OPENCLAW_GIT_REPO` default** in `scripts/setup.sh` and `scripts/upgrade.sh` is now `https://github.com/openclaw/openclaw`.
- **Env examples** (`.env.example`, `envs/local.env.example`, `envs/cloud.env.example`): same default URL and clearer comments (override for fork/mirror).
- **Docs**: `README.md` (upgrade path wording), `docs/INSTALL-linux.md`, `docs/INSTALL-macos.md` describe upstream as default.
- **`.cursor/rules/00-core.mdc`**: wording updated to “default upstream” and sibling checkout examples.

**User-facing behavior:** Fresh installs and upgrades that do not set `OPENCLAW_GIT_REPO` clone/pull from upstream. Existing deployments that already have `OPENCLAW_GIT_REPO` in `.env` are unchanged.

## How to test

- **Sanity (ran on PR branch):** `grep` on `scripts/setup.sh`, `scripts/upgrade.sh`, and `.env.example` confirms the default `OPENCLAW_GIT_REPO` is `https://github.com/openclaw/openclaw`. Optional: `shellcheck scripts/setup.sh scripts/upgrade.sh` if installed.

- **Manual:** On a clean machine or temp dir, run `./scripts/setup.sh` and confirm prompts / written `.env` use upstream unless you override `OPENCLAW_GIT_REPO`.

- **Environment:** Linux 6.17; full Docker flow not re-run for this doc/default-only change.

## Checklist

- [x] No secrets/tokens/private paths were committed (especially `.env`)
- [x] Docs updated if user workflow changed
- [x] Changes are scoped and easy to review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/configuration change that only affects fresh installs or upgrades where `OPENCLAW_GIT_REPO` is unset; existing deployments with an explicit repo URL are unchanged.
> 
> **Overview**
> Defaults the wrapper’s OpenClaw source clone/pull to upstream `https://github.com/openclaw/openclaw` when `OPENCLAW_GIT_REPO` is not provided, updating both `scripts/setup.sh` and `scripts/upgrade.sh` fallbacks.
> 
> Aligns `.env.example`, `envs/*.env.example`, install docs, README upgrade guidance, and `.cursor/rules/00-core.mdc` wording so the upstream repo is the documented default and forks/mirrors are treated as optional overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a68847a73500f3066995111b97f8e34353b766e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->